### PR TITLE
deprecate `Microgrid.run` in favor of `Microgrid.step`

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ certain number of steps, results can be viewed by calling microgrid.get_log.
 ```python
 >> for j in range(10):
 >>    action = microgrid.sample_action(strict_bound=True)
->>    microgrid.run(action)
+>>    microgrid.step(action)
 
 >> microgrid.get_log(drop_singleton_key=True)
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -130,34 +130,8 @@ def linkcode_resolve(domain, info):
         except AttributeError:
             return None
 
-    try:
-        fn = inspect.getsourcefile(inspect.unwrap(obj))
-    except TypeError:
-        try:  # property
-            fn = inspect.getsourcefile(inspect.unwrap(obj.fget))
-        except (AttributeError, TypeError):
-            fn = None
-    if not fn:
-        return None
+    return pymgrid.utils.obj_linkcode(obj)
 
-    try:
-        source, lineno = inspect.getsourcelines(obj)
-    except TypeError:
-        try:  # property
-            source, lineno = inspect.getsourcelines(obj.fget)
-        except (AttributeError, TypeError):
-            lineno = None
-    except OSError:
-        lineno = None
-
-    if lineno:
-        linespec = f"#L{lineno}-L{lineno + len(source) - 1}"
-    else:
-        linespec = ""
-
-    fn = os.path.relpath(fn, start=os.path.dirname(pymgrid.__file__))
-
-    return f'https://github.com/ahalev/python-microgrid/tree/v{pymgrid.__version__}/src/pymgrid/{fn}{linespec}'
 
 
 intersphinx_mapping = {

--- a/docs/source/reference/modules/index.rst
+++ b/docs/source/reference/modules/index.rst
@@ -60,3 +60,10 @@ Various battery transition models.
     BatteryTransitionModel
     BiasedTransitionModel
     DecayTransitionModel
+=======
+----------------
+
+.. toctree::
+   :maxdepth: 1
+
+   battery_transition_models/index

--- a/docs/source/reference/modules/index.rst
+++ b/docs/source/reference/modules/index.rst
@@ -60,10 +60,3 @@ Various battery transition models.
     BatteryTransitionModel
     BiasedTransitionModel
     DecayTransitionModel
-=======
-----------------
-
-.. toctree::
-   :maxdepth: 1
-
-   battery_transition_models/index

--- a/src/pymgrid/envs/base/base.py
+++ b/src/pymgrid/envs/base/base.py
@@ -233,8 +233,8 @@ class BaseMicrogridEnv(Microgrid, Env):
         action = self.convert_action(action)
         self._log_action(action, normalized)
 
-        _, reward, done, info = self.run(action, normalized=normalized)
-        obs = self._get_obs()
+        obs, reward, done, info = super().step(action, normalized=normalized)
+        obs = self._get_obs(obs)
         self.step_callback(**self._get_step_callback_info(action, obs, reward, done, info))
 
         return obs, reward, done, info

--- a/src/pymgrid/envs/base/base.py
+++ b/src/pymgrid/envs/base/base.py
@@ -234,7 +234,8 @@ class BaseMicrogridEnv(Microgrid, Env):
         self._log_action(action, normalized)
 
         obs, reward, done, info = super().step(action, normalized=normalized)
-        obs = self._get_obs(obs)
+        obs = self._get_obs()
+
         self.step_callback(**self._get_step_callback_info(action, obs, reward, done, info))
 
         return obs, reward, done, info

--- a/src/pymgrid/microgrid/microgrid.py
+++ b/src/pymgrid/microgrid/microgrid.py
@@ -12,6 +12,7 @@ from pymgrid.utils.eq import verbose_eq
 from pymgrid.utils.logger import ModularLogger
 from pymgrid.utils.serialize import add_numpy_pandas_representers, add_numpy_pandas_constructors, dump_data
 from pymgrid.utils.space import MicrogridSpace
+from pymgrid.utils.deprecation import deprecation_warning
 
 
 class Microgrid(yaml.YAMLObject):
@@ -225,7 +226,11 @@ class Microgrid(yaml.YAMLObject):
             self._set_initial_step(initial_step, modules_only=True)
             self._set_final_step(final_step, modules_only=True)
 
+    @deprecation_warning('step')
     def run(self, control, normalized=True):
+        return self.step(control, normalized=normalized)
+
+    def step(self, control, normalized=True):
         """
 
         Run the microgrid for a single step.

--- a/src/pymgrid/microgrid/microgrid.py
+++ b/src/pymgrid/microgrid/microgrid.py
@@ -226,7 +226,7 @@ class Microgrid(yaml.YAMLObject):
             self._set_initial_step(initial_step, modules_only=True)
             self._set_final_step(final_step, modules_only=True)
 
-    @deprecation_warning('step')
+    @deprecation_warning('Microgrid.step')
     def run(self, control, normalized=True):
         return self.step(control, normalized=normalized)
 

--- a/src/pymgrid/utils/__init__.py
+++ b/src/pymgrid/utils/__init__.py
@@ -1,2 +1,3 @@
 from .dry_run import dry_run
 from .serialize import add_pymgrid_yaml_representers
+from .code_link import obj_linkcode

--- a/src/pymgrid/utils/code_link.py
+++ b/src/pymgrid/utils/code_link.py
@@ -1,0 +1,34 @@
+import inspect
+import os
+import pymgrid
+
+
+def obj_linkcode(obj):
+    try:
+        fn = inspect.getsourcefile(inspect.unwrap(obj))
+    except TypeError:
+        try:  # property
+            fn = inspect.getsourcefile(inspect.unwrap(obj.fget))
+        except (AttributeError, TypeError):
+            fn = None
+    if not fn:
+        return None
+
+    try:
+        source, lineno = inspect.getsourcelines(obj)
+    except TypeError:
+        try:  # property
+            source, lineno = inspect.getsourcelines(obj.fget)
+        except (AttributeError, TypeError):
+            lineno, source = None, ''
+    except OSError:
+        lineno, source = None, ''
+
+    if lineno:
+        linespec = f"#L{lineno}-L{lineno + len(source) - 1}"
+    else:
+        linespec = ""
+
+    fn = os.path.relpath(fn, start=os.path.dirname(pymgrid.__file__))
+
+    return f'https://github.com/ahalev/python-microgrid/tree/v{pymgrid.__version__}/src/pymgrid/{fn}{linespec}'

--- a/src/pymgrid/utils/deprecation.py
+++ b/src/pymgrid/utils/deprecation.py
@@ -1,0 +1,52 @@
+import functools
+import warnings
+
+
+def deprecation_warning(successor, msg=None):
+    # TODO (ahalev) use obj_linkcode here
+    """
+    Decorator for warning of future deprecation
+
+    Raises a DeprecationWarning on the wrapped function and suggests using `successor` instead.
+    If msg is not None, raises a future warning with said message. In this case `successor` is ignored.
+    """
+
+    def decorator(func):
+
+        @functools.wraps(func)
+        def wrapper(self, *args, **kwargs):
+            _msg = msg or f"Function '{func.__qualname__}' is deprecated and will be removed in a future version. "\
+                          f"Use '{successor}' instead."
+
+            warnings.warn(_msg, category=DeprecationWarning)
+
+            return func(self, *args, **kwargs)
+        return wrapper
+    return decorator
+
+
+def deprecation_err(successor, msg=None):
+    # TODO (ahalev) use obj_linkcode here
+    """
+    Decorator for warning of future deprecation
+
+    Raises a DeprecationWarning on the wrapped function and suggests using `successor` instead.
+    If msg is not None, raises a future warning with said message. In this case `successor` is ignored.
+    """
+
+    def decorator(func):
+
+        @functools.wraps(func)
+        def wrapper(self, *args, **kwargs):
+            # TODO (ahalev) get this version
+            _msg = msg or f"Function '{func.__name__}' is deprecated as of version {'version'}. "\
+                          f"Use '{successor}' instead."
+
+            raise DeprecatedError(_msg)
+
+        return wrapper
+    return decorator
+
+
+class DeprecatedError(Exception):
+    pass


### PR DESCRIPTION


<!-- readthedocs-preview python-microgrid start -->
----
:books: Documentation preview :books:: https://python-microgrid--86.org.readthedocs.build/en/86/

<!-- readthedocs-preview python-microgrid end -->