### PR TITLE
test net load

### DIFF
--- a/src/pymgrid/envs/base/base.py
+++ b/src/pymgrid/envs/base/base.py
@@ -278,7 +278,7 @@ class BaseMicrogridEnv(Microgrid, Env):
 
         self._microgrid_logger.log(d)
 
-    def _get_obs(self, obs):
+    def _get_obs(self):
         if self.observation_keys:
             obs = self.state_series(normalized=True).loc[pd.IndexSlice[:, :, self.observation_keys]]
 
@@ -288,7 +288,9 @@ class BaseMicrogridEnv(Microgrid, Env):
                 obs = obs.to_frame().unstack(level=1).T.droplevel(level=1, axis=1).to_dict(orient='list')
 
         elif self._flat_spaces:
-            obs = self.flatten_obs(self._nested_observation_space, obs)
+            obs = self.state_series(normalized=True).values
+        else:
+            obs = self.state_dict(normalized=True, as_run_output=True)
 
         return obs
 

--- a/src/pymgrid/envs/base/base.py
+++ b/src/pymgrid/envs/base/base.py
@@ -189,11 +189,9 @@ class BaseMicrogridEnv(Microgrid, Env):
         return self.state_series().index.get_level_values(-1).unique()
 
     def reset(self):
-        obs = super().reset()
-        obs.pop('balance')
-        obs.pop('other')
+        super().reset()
         self.reset_callback()
-        return self._get_obs(obs)
+        return self._get_obs()
 
     def step(self, action, normalized=True):
         """
@@ -235,8 +233,8 @@ class BaseMicrogridEnv(Microgrid, Env):
         action = self.convert_action(action)
         self._log_action(action, normalized)
 
-        obs, reward, done, info = self.run(action, normalized=normalized)
-        obs = self._get_obs(obs)
+        _, reward, done, info = self.run(action, normalized=normalized)
+        obs = self._get_obs()
         self.step_callback(**self._get_step_callback_info(action, obs, reward, done, info))
 
         return obs, reward, done, info

--- a/src/pymgrid/envs/base/base.py
+++ b/src/pymgrid/envs/base/base.py
@@ -343,9 +343,7 @@ class BaseMicrogridEnv(Microgrid, Env):
 
         return net_load
 
-    def state_dict(self, normalized=False, as_run_output=False):
-        sd = super().state_dict(normalized=normalized, as_run_output=as_run_output)
-
+    def state_dict(self, normalized=False, as_run_output=False, _initial=None):
         net_load = self.compute_net_load(normalized=normalized)
 
         if as_run_output:
@@ -353,9 +351,8 @@ class BaseMicrogridEnv(Microgrid, Env):
         else:
             net_load_entry = {'net_load': net_load}
 
-        sd['general'] = [net_load_entry]
-
-        return sd
+        state_dict = {'general': [net_load_entry]}
+        return super().state_dict(normalized=normalized, as_run_output=as_run_output, _initial=state_dict)
 
     @staticmethod
     def flatten_obs(observation_space, obs):

--- a/src/pymgrid/envs/base/base.py
+++ b/src/pymgrid/envs/base/base.py
@@ -160,26 +160,23 @@ class BaseMicrogridEnv(Microgrid, Env):
             for module_num, module in enumerate(module_list):
                 normalized_space = module.observation_space['normalized']
 
-                if not self.observation_keys:
-                    tup.append(normalized_space)
-                else:
-                    try:
-                        relevant_state_idx = state_series.loc[pd.IndexSlice[name, module_num]].index
-                    except KeyError:
-                        continue
+                try:
+                    relevant_state_idx = state_series.loc[pd.IndexSlice[name, module_num]].index
+                except KeyError:
+                    continue
 
-                    locs = [
-                        relevant_state_idx.get_loc(key) for key in self.observation_keys if key in relevant_state_idx
-                    ]
-                    if locs:
-                        box_slice = Box(
-                            normalized_space.low[locs],
-                            normalized_space.high[locs],
-                            shape=(len(locs), ),
-                            dtype=normalized_space.dtype
-                        )
+                locs = [
+                    relevant_state_idx.get_loc(key) for key in observation_keys if key in relevant_state_idx
+                ]
+                if locs:
+                    box_slice = Box(
+                        normalized_space.low[locs],
+                        normalized_space.high[locs],
+                        shape=(len(locs), ),
+                        dtype=normalized_space.dtype
+                    )
 
-                        tup.append(box_slice)
+                    tup.append(box_slice)
             if tup:
                 obs_space[name] = Tuple(tup)
 

--- a/src/pymgrid/envs/base/base.py
+++ b/src/pymgrid/envs/base/base.py
@@ -148,10 +148,12 @@ class BaseMicrogridEnv(Microgrid, Env):
     def _get_observation_space(self):
         obs_space = {}
 
-        if self.observation_keys and 'net_load' in self.observation_keys:
-            obs_space['net_load'] = Tuple([Box(low=-np.inf, high=1, shape=(1, ), dtype=np.float64)])
-
         state_series = self.state_series()
+
+        observation_keys = self.observation_keys or state_series.index.get_level_values(-1)
+
+        if 'net_load' in observation_keys:
+            obs_space['general'] = Tuple([Box(low=-np.inf, high=1, shape=(1, ), dtype=np.float64)])
 
         for name, module_list in self.modules.iterdict():
             tup = []

--- a/src/pymgrid/envs/base/base.py
+++ b/src/pymgrid/envs/base/base.py
@@ -356,7 +356,7 @@ class BaseMicrogridEnv(Microgrid, Env):
 
     @staticmethod
     def flatten_obs(observation_space, obs):
-        return np.concatenate([flatten(observation_space[k], v) for k, v in obs.items()])
+        return np.concatenate([flatten(space, obs[k]) for k, space in observation_space.items()])
 
     @property
     def unwrapped(self):

--- a/src/pymgrid/microgrid/microgrid.py
+++ b/src/pymgrid/microgrid/microgrid.py
@@ -731,7 +731,7 @@ class Microgrid(yaml.YAMLObject):
         """
         return self._modules
 
-    def state_dict(self, normalized=False, as_run_output=False):
+    def state_dict(self, normalized=False, as_run_output=False, _initial=None):
         """
         State of the microgrid as a dict.
 
@@ -746,6 +746,8 @@ class Microgrid(yaml.YAMLObject):
             Whether to return output in the same format as the output of :meth:`Microgrid.run`.
             Inner values are numpy arrays and not dict in this case.
 
+        _initial : dict or None
+            Internal parameter, do not use.
 
         Returns
         -------
@@ -758,9 +760,12 @@ class Microgrid(yaml.YAMLObject):
                 return np.array(list(state_dict.values()))
             return state_dict
 
-        return {name: [
-            as_run_output_f(module.state_dict(normalized=normalized)) for module in modules
-        ] for name, modules in self._modules.iterdict()}
+        state_dict = _initial or dict()
+
+        for name, modules in self._modules.iterdict():
+            state_dict[name] = [as_run_output_f(module.state_dict(normalized=normalized)) for module in modules]
+
+        return state_dict
 
     @property
     def log(self):

--- a/src/pymgrid/microgrid/reward_shaping/baseline_shaper.py
+++ b/src/pymgrid/microgrid/reward_shaping/baseline_shaper.py
@@ -50,8 +50,13 @@ class BaselineShaper(BaseRewardShaper):
 
         if self.baseline_module:
             if self.baseline_module == self.module:
-                return reward / baseline_cost
+                scale = baseline_cost
+            else:
+                scale = self.compute_baseline_cost(step_info, cost_info, baseline_module=self.baseline_module)
 
-            return reward / self.compute_baseline_cost(step_info, cost_info, baseline_module=self.baseline_module)
+            scale = max(scale, 1.0)
+
+            return reward / scale
+
 
         return reward

--- a/tests/envs/test_base.py
+++ b/tests/envs/test_base.py
@@ -1,0 +1,163 @@
+import functools
+import numpy as np
+import pandas as pd
+
+from copy import deepcopy
+
+from tests.helpers.test_case import TestCase
+from tests.helpers.modular_microgrid import get_modular_microgrid
+
+from pymgrid.envs import DiscreteMicrogridEnv, ContinuousMicrogridEnv, NetLoadContinuousMicrogridEnv
+from pymgrid.envs.base import BaseMicrogridEnv
+
+
+def pass_if_parent(func):
+    @functools.wraps(func)
+    def wrapper(self, *args, **kwargs):
+        if self.env_class is not None:
+            return func(self, *args, **kwargs)
+
+    return wrapper
+
+
+class Parent(TestCase):
+    env_class: BaseMicrogridEnv = None
+    observation_keys = ()
+
+    @pass_if_parent
+    def setUp(self) -> None:
+        self.env = self.env_class.from_microgrid(get_modular_microgrid(), observation_keys=self.observation_keys)
+
+    @pass_if_parent
+    def test_reset_obs_in_obs_space(self):
+        env = deepcopy(self.env)
+        obs = env.reset()
+
+        self.assertIn(obs, env.observation_space)
+
+    @pass_if_parent
+    def test_pre_reset_state_series_invariant_to_observation_keys(self):
+        env = deepcopy(self.env)
+
+        self.assertEqual(env.state_series().shape, (13, ))
+
+    @pass_if_parent
+    def test_flattened_state_dict_is_state_series(self):
+        env = deepcopy(self.env)
+
+        state_dict = env.state_dict(normalized=True, as_run_output=True)
+        flattened_state_dict = flatten_nested_dict(state_dict)
+
+        self.assertEqual(flattened_state_dict, env.state_series(normalized=True).values)
+
+    @pass_if_parent
+    def test_pre_reset_state_dict_invariant_to_observation_keys(self):
+        env = deepcopy(self.env)
+        state_dict = env.state_dict()
+
+        n_state_dict_values = functools.reduce(lambda x, y: x+len(y[0]), state_dict.values(), 0)
+
+        self.assertEqual(n_state_dict_values, 13)
+
+    @pass_if_parent
+    def test_obs_values_after_reset(self):
+        env = deepcopy(self.env)
+        obs = env.reset()
+
+        if self.observation_keys:
+            expected_obs = env.state_series(normalized=True).loc[pd.IndexSlice[:, :, self.observation_keys]].values
+        else:
+            expected_obs = env.state_series(normalized=True).values
+
+        self.assertEqual(obs, expected_obs)
+
+    @pass_if_parent
+    def test_state_series_values(self):
+        env = deepcopy(self.env)
+
+        expected_state_series = np.array([10., -60., 50., 1., 1., 0., 0., 0.5, 50., 1., 1., 1., 1.])
+        self.assertEqual(env.state_series(normalized=False).values, expected_state_series)
+
+    @pass_if_parent
+    def test_state_series_values_normalized(self):
+        env = deepcopy(self.env)
+
+        expected_state_series = np.array([1/6., 0., 1., 1., 1., 0., 0., 0.5, 0.5, 0., 0., 0., 0.])
+        self.assertEqual(env.state_series(normalized=True).values, expected_state_series)
+
+    @pass_if_parent
+    def test_get_obs(self):
+        env = deepcopy(self.env)
+        obs = env._get_obs()
+
+        if self.observation_keys:
+            expected_obs = env.state_series(normalized=True).loc[pd.IndexSlice[:, :, self.observation_keys]].values
+        else:
+            expected_obs = env.state_series(normalized=True).values
+
+        self.assertEqual(obs, expected_obs)
+
+    @pass_if_parent
+    def test_steps(self):
+        env = deepcopy(self.env)
+
+        env.reset()
+
+        for j in range(10):
+            with self.subTest(step=j):
+                obs, _, _, _ = env.step(env.action_space.sample())
+                self.assertTrue((obs >= 0).all())
+                self.assertTrue((obs <= 1).all())
+
+
+class ObsKeysNoNetLoadParent(Parent):
+    observation_keys = ['soc', 'import_price_current', 'goal_status', 'load_current', 'renewable_current']
+
+    @pass_if_parent
+    def test_get_obs_correct_keys_in_modules(self):
+        env = deepcopy(self.env)
+        obs = env._get_obs()
+
+        for module in env.modules.iterlist():
+            module_state_dict = module.state_dict(normalized=True)
+            matching_keys = [obs_key for obs_key in self.observation_keys if obs_key in module.state_dict().keys()]
+            matching_values = [module_state_dict[k] for k in matching_keys]
+
+            with self.subTest(module=module.name, keys=matching_keys):
+                self.assertEqual(obs[np.isin(self.observation_keys, matching_keys)], matching_values)
+
+
+class ObsKeysWithNetLoadParent(ObsKeysNoNetLoadParent):
+    observation_keys = ['net_load', 'soc', 'load_current', 'export_price_current']
+
+
+class TestDiscrete(Parent):
+    env_class = DiscreteMicrogridEnv
+
+
+class TestContinuous(Parent):
+    env_class = ContinuousMicrogridEnv
+
+
+class TestNetLoadContinuous(Parent):
+    env_class = NetLoadContinuousMicrogridEnv
+
+
+class TestDiscreteObsKeysNoNetLoad(ObsKeysNoNetLoadParent):
+    env_class = DiscreteMicrogridEnv
+
+
+class TestContinuousObsKeysNoNetLoad(ObsKeysNoNetLoadParent):
+    env_class = ContinuousMicrogridEnv
+
+
+class TestNetLoadContinuousObsKeysNoNetLoad(ObsKeysNoNetLoadParent):
+    env_class = NetLoadContinuousMicrogridEnv
+
+
+def flatten_nested_dict(nested_dict):
+    def extract_list(l):
+        assert len(l) == 1, 'reduction only works with length 1 lists'
+        return l[0].tolist()
+
+    return functools.reduce(lambda x, y: x + extract_list(y), nested_dict.values(), [])

--- a/tests/envs/test_continuous_net_load.py
+++ b/tests/envs/test_continuous_net_load.py
@@ -21,7 +21,8 @@ class TestNetLoadContinuousEnv(TestCase):
         self.assertEqual(env.modules, microgrid.modules)
         self.assertIsNot(env.modules.to_tuples(), microgrid.modules.to_tuples())
 
-        n_obs = sum([x.observation_space['normalized'].shape[0] for x in microgrid.modules.to_list()])
+        # add one for net load
+        n_obs = 1 + sum([x.observation_space['normalized'].shape[0] for x in microgrid.modules.to_list()])
 
         self.assertEqual(env.observation_space.shape, (n_obs,))
 
@@ -208,7 +209,8 @@ class TestNetLoadContinuousEnvSlackModule(TestCase):
         self.assertIn('genset', action_space_keys)
         self.assertNotIn('grid', action_space_keys)
 
-        n_obs = sum([x.observation_space['normalized'].shape[0] for x in microgrid.modules.to_list()])
+        # add one for net load
+        n_obs = 1 + sum([x.observation_space['normalized'].shape[0] for x in microgrid.modules.to_list()])
 
         self.assertEqual(env.observation_space.shape, (n_obs,))
 

--- a/tests/envs/test_discrete.py
+++ b/tests/envs/test_discrete.py
@@ -16,7 +16,8 @@ class TestDiscreteEnv(TestCase):
         self.assertEqual(env.modules, microgrid.modules)
         self.assertIsNot(env.modules.to_tuples(), microgrid.modules.to_tuples())
 
-        n_obs = sum([x.observation_space['normalized'].shape[0] for x in microgrid.modules.to_list()])
+        # Add one for net load
+        n_obs = 1 + sum([x.observation_space['normalized'].shape[0] for x in microgrid.modules.to_list()])
 
         self.assertEqual(env.observation_space.shape, (n_obs,))
 
@@ -27,7 +28,8 @@ class TestDiscreteEnv(TestCase):
         self.assertEqual(env.modules, microgrid.modules)
         self.assertIsNot(env.modules.to_tuples(), microgrid.modules.to_tuples())
 
-        n_obs = sum([x.observation_space['normalized'].shape[0] for x in microgrid.modules.to_list()])
+        # Add one for net load
+        n_obs = 1 + sum([x.observation_space['normalized'].shape[0] for x in microgrid.modules.to_list()])
 
         self.assertEqual(env.observation_space.shape, (n_obs,))
 


### PR DESCRIPTION
* update _get_obs to not use input
* put net load in obs_space if no observation_keys
* this has been rebased on #88 to undo various broken things
* this is the broken thing: d089de24af960c9139b7e45ff11d134ef4be050a

<!-- readthedocs-preview python-microgrid start -->
----
:books: Documentation preview :books:: https://python-microgrid--87.org.readthedocs.build/en/87/

<!-- readthedocs-preview python-microgrid end -->