### PR TITLE
revert + cherry pick

### DIFF
--- a/src/pymgrid/envs/continuous/continuous.py
+++ b/src/pymgrid/envs/continuous/continuous.py
@@ -124,9 +124,10 @@ class NetLoadContinuousMicrogridEnv(BaseMicrogridEnv):
                 self._slack_module_ref = controllable_modules_dict_lists[self._slack_module].item()
                 self._slack_module = self._slack_module_ref.name
             except ValueError:
-                msg = f"Module name {self._slack_module} does not point to one controllable candidate."
+                msg = f"Module name {self._slack_module} does not point to unique controllable candidate."
             except KeyError:
-                msg = f"No module '{self._slack_module}' amongst controllable candidates {controllable_modules_dict}"
+                msg = f"No module '{self._slack_module}' amongst controllable candidates " \
+                      f"{list(controllable_modules_dict.keys())}"
 
             if msg:
                 raise NameError(msg)

--- a/src/pymgrid/envs/continuous/continuous.py
+++ b/src/pymgrid/envs/continuous/continuous.py
@@ -238,4 +238,8 @@ def clip_module_action(action, module):
     low = -1 * module.max_consumption
     high = module.max_production
 
+    if len(action) > 1:
+        low = [*module.action_space.unnormalized.low[:-1], low]
+        high = [*module.action_space.unnormalized.high[:-1], high]
+
     return module.action_space.clip(action, low=low, high=high)

--- a/src/pymgrid/modules/base/base_module.py
+++ b/src/pymgrid/modules/base/base_module.py
@@ -278,20 +278,19 @@ class BaseMicrogridModule(yaml.YAMLObject):
         return self.update(absorbed_energy, as_sink=True)
 
     def _log(self, state_dict_pre_step, provided_energy=None, absorbed_energy=None, **info):
-        _info = info.copy()
+        energy_info = dict()
 
         if self.provided_energy_name is not None:
-            _info[self.provided_energy_name] = provided_energy if provided_energy is not None else 0.0
+            energy_info[self.provided_energy_name] = provided_energy if provided_energy is not None else 0.0
         else:
             assert provided_energy is None, 'Cannot log provided_energy with NoneType provided_energy_name.'
 
         if self.absorbed_energy_name is not None:
-            _info[self.absorbed_energy_name] = absorbed_energy if absorbed_energy is not None else 0.0
+            energy_info[self.absorbed_energy_name] = absorbed_energy if absorbed_energy is not None else 0.0
         else:
             assert absorbed_energy is None, 'Cannot log absorbed_energy with NoneType absorbed_energy_name.'
 
-        _info.update(state_dict_pre_step)
-        self._logger.log(**_info)
+        self._logger.log(**info, **energy_info, **state_dict_pre_step)
 
     def _update_step(self, reset=False):
         if reset:

--- a/src/pymgrid/modules/module_container.py
+++ b/src/pymgrid/modules/module_container.py
@@ -312,7 +312,7 @@ class Container(UserDict):
                 raise KeyError(item)
 
     def __getattr__(self, item):
-        if item == 'data' or item.startswith('__') or item not in dir(self):
+        if item == 'data' or item.startswith('__'):
             raise AttributeError(item)
         try:
             return self[item]

--- a/src/pymgrid/utils/space/space.py
+++ b/src/pymgrid/utils/space/space.py
@@ -353,13 +353,13 @@ class ModuleSpace(_PymgridSpace):
             return denormalized
 
     def _bounds_check(self, val, low, high):
-        clipped = np.clip(val, low, high)
-
-        if self.verbose or not self.clip_vals and (clipped != val).any():
+        if (low <= val).all() & (val <= high).all():
+            return val
+        elif self.verbose or not self.clip_vals:
             warnings.warn(f'Value {val} resides out of expected bounds of value to be normalized: [{low}, {high}].')
 
         if self.clip_vals:
-            return clipped
+            return np.clip(val, low, high)
 
         return val
 

--- a/tests/envs/test_continuous_net_load.py
+++ b/tests/envs/test_continuous_net_load.py
@@ -335,6 +335,28 @@ class TestNetLoadContinuousEnvSlackModule(TestCase):
                 with self.subTest(module_name=module_name, module_num=module_num):
                     self.assertEqual(act, absolute_action[module_name][module_num])
 
+    def test_convert_action_to_absolute_negative_net_load_with_clip_out_of_range_genset_status(self):
+        new_renewable_module = RenewableModule(time_series=70*np.ones(100))
+        microgrid = get_modular_microgrid(remove_modules=['renewable'], additional_modules=[new_renewable_module])
+
+        env = NetLoadContinuousMicrogridEnv.from_microgrid(microgrid, slack_module=('grid', 0))
+
+        self.assertEqual(env.compute_net_load(), -10.0)
+
+        expected_absolute_action = {
+            'battery': [np.array([-5.])],
+            'genset': [np.array([1.0, 0])],
+            'grid': [np.array([-5.])]
+        }
+        relative_action = np.array([0.5, 1.1, 0.25])
+
+        absolute_action = env.convert_action(relative_action)
+
+        for module_name, action_list in expected_absolute_action.items():
+            for module_num, act in enumerate(action_list):
+                with self.subTest(module_name=module_name, module_num=module_num):
+                    self.assertEqual(act, absolute_action[module_name][module_num])
+
     def test_convert_action_to_absolute_negative_net_load_no_clip(self):
         new_renewable_module = RenewableModule(time_series=70*np.ones(100))
         microgrid = get_modular_microgrid(remove_modules=['renewable'], additional_modules=[new_renewable_module])


### PR DESCRIPTION
* This branch has a base of #88 and #87 (in that order)
* The code state in #87 should be working properly. If something is broken, it's likely b/w then and current commit
* There are some uncommited things that have been reverted, these can be seen in [ahalev_efficiency_revert](https://github.com/ahalev/python-microgrid/tree/ahalev_efficiency_revert).
<!-- readthedocs-preview python-microgrid start -->
----
:books: Documentation preview :books:: https://python-microgrid--89.org.readthedocs.build/en/89/

<!-- readthedocs-preview python-microgrid end -->